### PR TITLE
Removed deprecated package ugettext_lazy by django instead updated to gettext_lazy

### DIFF
--- a/django_selenium_pdfmaker/models.py
+++ b/django_selenium_pdfmaker/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def file_upload_to(instance, filename):

--- a/django_selenium_pdfmaker/modules.py
+++ b/django_selenium_pdfmaker/modules.py
@@ -7,7 +7,7 @@ from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.chrome.options import Options
 from webdriver_manager.chrome import ChromeDriverManager
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from .settings import *
 
 MODULE_PATH = os.path.abspath(__file__)  # Get path of current module file (modules.py file)


### PR DESCRIPTION
This pull request will resolve the #7 issue 